### PR TITLE
Add Subject Alternative Names (restricted) support in scripts/le.sh

### DIFF
--- a/script/le.sh
+++ b/script/le.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
 if [ "$LETSENCRYPT" = "true" ]; then
-    certbot certonly -t -n --agree-tos --renew-by-default --email "${LE_EMAIL}" --webroot -w /usr/share/nginx/html -d $LE_FQDN
-    cp -fv /etc/letsencrypt/live/$LE_FQDN/privkey.pem /etc/nginx/ssl/le-key.pem
-    cp -fv /etc/letsencrypt/live/$LE_FQDN/fullchain.pem /etc/nginx/ssl/le-crt.pem
+    DOMAINS=$(echo ${LE_FQDN} | sed s'|,| -d |g')
+    FQDN=$(echo ${DOMAINS} | cut -f1 -d ' ')
+    certbot certonly -t -n --agree-tos --renew-by-default --email "${LE_EMAIL}" --webroot -w /usr/share/nginx/html -d ${DOMAINS}
+    cp -fv /etc/letsencrypt/live/${FQDN}/privkey.pem /etc/nginx/ssl/le-key.pem
+    cp -fv /etc/letsencrypt/live/${FQDN}/fullchain.pem /etc/nginx/ssl/le-crt.pem
 else
     echo "letsencrypt disabled"
 fi


### PR DESCRIPTION
Hi,

This patch allow request certificates for multiple domains (SAN).

Example usage:

```
LQ_FQDN: example.com,www.example.com
```

It works for me, but have some issues/future improvements:
* path to certificate/keys include first domain name in list (in example will be: `example.com`);
* certbot allow multiple `--webroot` and `-d`, but this implementaion doesn't support it.