### PR TITLE
 Copy chain.pem for nginx ssl_trusted_certificate directive 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Simple nginx image (alpine based) with integrated [Let's Encrypt](https://letsen
     - set `LETSENCRYPT=true` if you want automatic certificate install and renewal
     - `LE_EMAIL` should be your email and `LE_FQDN` for domain
     - for multiple FQDNs you can pass comma-separated list, like `LE_FQDN=aaa.example.com,bbb.example.com`
-    - alternatively set `LETSENCRYPT` to `false` and pass your own cert and key in `SSL_CERT` and `SSL_KEY`
+    - alternatively set `LETSENCRYPT` to `false` and pass your own cert and key in `SSL_CERT` and `SSL_KEY` (and `SSL_CHAIN_CERT` if you need it)
 
 - use provided `etc/service-example.conf` to make your own `etc/service.conf`. Keep both `ssl_certificate SSL_CERT;` and `ssl_certificate_key SSL_KEY;`
+    - if you need [stapling of OCSP responses](https://tools.ietf.org/html/rfc4366#section-3.6), uncomment section starting with `ssl_trusted_certificate SSL_CHAIN_CERT;` in `service.conf`
 - make sure `volumes` in docker-compose.yml changed to your service config
 - you can map multiple config files in compose, for instance `- ./conf.d:/etc/nginx/conf.d`
 - pull image - `docker-compose pull`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,3 +29,4 @@ services:
             - LE_FQDN=www.example.com
             #- SSL_CERT=le-crt.pem
             #- SSL_KEY=le-key.pem
+            #- SSL_CHAIN_CERT=le-chain-crt.pem

--- a/etc/service-example.conf
+++ b/etc/service-example.conf
@@ -5,8 +5,14 @@ server {
     root /srv/docroot/;
 
     ssl    on;
-    ssl_certificate        SSL_CERT;
-    ssl_certificate_key    SSL_KEY;
+    ssl_certificate         SSL_CERT;
+    ssl_certificate_key     SSL_KEY;
+
+    # uncomment to enable stapling of OCSP responses
+    #ssl_trusted_certificate SSL_CHAIN_CERT;
+    #resolver 8.8.8.8 [2001:4860:4860::8888];
+    #ssl_stapling on;
+    #ssl_stapling_verify on;
 
     add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
 

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -2,8 +2,8 @@
 echo "start nginx"
 
 #set TZ
-cp /usr/share/zoneinfo/$TZ /etc/localtime && \
-echo $TZ > /etc/timezone && \
+cp /usr/share/zoneinfo/${TZ} /etc/localtime && \
+echo ${TZ} > /etc/timezone && \
 
 #setup ssl keys
 echo "ssl_key=${SSL_KEY:=le-key.pem}, ssl_cert=${SSL_CERT:=le-crt.pem}"

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -6,9 +6,11 @@ cp /usr/share/zoneinfo/${TZ} /etc/localtime && \
 echo ${TZ} > /etc/timezone && \
 
 #setup ssl keys
-echo "ssl_key=${SSL_KEY:=le-key.pem}, ssl_cert=${SSL_CERT:=le-crt.pem}"
+echo "ssl_key=${SSL_KEY:=le-key.pem}, ssl_cert=${SSL_CERT:=le-crt.pem}, ssl_chain_cert=${SSL_CHAIN_CERT:=le-chain-crt.pem}"
 SSL_KEY=/etc/nginx/ssl/${SSL_KEY}
 SSL_CERT=/etc/nginx/ssl/${SSL_CERT}
+SSL_CHAIN_CERT=/etc/nginx/ssl/${SSL_CHAIN_CERT}
+
 mkdir -p /etc/nginx/conf.d
 mkdir -p /etc/nginx/ssl
 
@@ -17,9 +19,10 @@ if [ -f /etc/nginx/service.conf ]; then
     cp -fv /etc/nginx/service.conf /etc/nginx/conf.d/service.conf
 fi
 
-#replace SSL_KEY and SSL_CERT by actual keys
+#replace SSL_KEY, SSL_CERT and SSL_CHAIN_CERT by actual keys
 sed -i "s|SSL_KEY|${SSL_KEY}|g" /etc/nginx/conf.d/*.conf
 sed -i "s|SSL_CERT|${SSL_CERT}|g" /etc/nginx/conf.d/*.conf
+sed -i "s|SSL_CHAIN_CERT|${SSL_CHAIN_CERT}|g" /etc/nginx/conf.d/*.conf
 
 #generate dhparams.pem
 if [ ! -f /etc/nginx/ssl/dhparams.pem ]; then

--- a/script/le.sh
+++ b/script/le.sh
@@ -5,6 +5,7 @@ if [ "$LETSENCRYPT" = "true" ]; then
     FIRST_FQDN=$(echo "$LE_FQDN" | cut -d"," -f1)
     cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/privkey.pem /etc/nginx/ssl/le-key.pem
     cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/fullchain.pem /etc/nginx/ssl/le-crt.pem
+    cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/chain.pem /etc/nginx/ssl/le-chain-crt.pem
 else
     echo "letsencrypt disabled"
 fi

--- a/script/le.sh
+++ b/script/le.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 if [ "$LETSENCRYPT" = "true" ]; then
-    certbot certonly -t -n --agree-tos --renew-by-default --email "${LE_EMAIL}" --webroot -w /usr/share/nginx/html -d $LE_FQDN
+    certbot certonly -t -n --agree-tos --renew-by-default --email "${LE_EMAIL}" --webroot -w /usr/share/nginx/html -d ${LE_FQDN}
     FIRST_FQDN=$(echo "$LE_FQDN" | cut -d"," -f1)
-    cp -fv /etc/letsencrypt/live/$FIRST_FQDN/privkey.pem /etc/nginx/ssl/le-key.pem
-    cp -fv /etc/letsencrypt/live/$FIRST_FQDN/fullchain.pem /etc/nginx/ssl/le-crt.pem
+    cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/privkey.pem /etc/nginx/ssl/le-key.pem
+    cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/fullchain.pem /etc/nginx/ssl/le-crt.pem
 else
     echo "letsencrypt disabled"
 fi


### PR DESCRIPTION
To enable [stapling of OCSP responses](https://tools.ietf.org/html/rfc4366#section-3.6) one should have `ssl_trusted_certificate` directive set and at the moment only way to do it is by using `/etc/letsencrypt/live/<domain>/chain.pem` path.

This patch delivers this file to location `/etc/nginx/ssl/le-chain-crt.pem`. Patch adds commented out parts to nginx.conf to make new option easy to enable but keep things same way as they were before.

Effectively nothing changes for this image users, except new `le-chain-crt.pem` file delivery.