### PR TITLE
Only renew certificate if expires within 30 days

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -46,7 +46,7 @@ mv -v /etc/nginx/conf.d /etc/nginx/conf.d.disabled
     mv -v /etc/nginx/conf.d.disabled /etc/nginx/conf.d #enable
     echo "reload nginx with ssl"
     nginx -s reload
-    sleep 60d
+    sleep 1d
  done
 ) &
 

--- a/script/le.sh
+++ b/script/le.sh
@@ -1,11 +1,22 @@
 #!/bin/sh
 
-if [ "$LETSENCRYPT" = "true" ]; then
-    certbot certonly -t -n --agree-tos --renew-by-default --email "${LE_EMAIL}" --webroot -w /usr/share/nginx/html -d ${LE_FQDN}
-    FIRST_FQDN=$(echo "$LE_FQDN" | cut -d"," -f1)
-    cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/privkey.pem /etc/nginx/ssl/le-key.pem
-    cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/fullchain.pem /etc/nginx/ssl/le-crt.pem
-    cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/chain.pem /etc/nginx/ssl/le-chain-crt.pem
-else
+target_cert=/etc/nginx/ssl/le-crt.pem
+# 30 days
+renew_before=2592000
+
+if [ "$LETSENCRYPT" != "true" ]; then
     echo "letsencrypt disabled"
+    return 0
 fi
+
+if [ -f ${target_cert} ] && openssl x509 -checkend  ${renew_before} -noout -in ${target_cert} ; then
+    echo "letsencrypt certificate still valid"
+    return 0
+fi
+
+echo "letsencrypt certificate invalid, renewing..."
+certbot certonly -t -n --agree-tos --renew-by-default --email "${LE_EMAIL}" --webroot -w /usr/share/nginx/html -d ${LE_FQDN}
+FIRST_FQDN=$(echo "$LE_FQDN" | cut -d"," -f1)
+cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/privkey.pem /etc/nginx/ssl/le-key.pem
+cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/fullchain.pem ${target_cert}
+cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/chain.pem /etc/nginx/ssl/le-chain-crt.pem


### PR DESCRIPTION
This is a quick hack to not hammer the LE API and thus not hit the weekly limit, if, for instance, your container keeps restarting.

The openssl incantation will only check the certificate expiration time, and not whether it is valid (ie. checking against the system CA store) - implementing that is left as an exercise to the reader.

We also make the renew check happen every day, instead of every 60 days, now that we can afford it.

This fixes #13 .