### PR TITLE
Fixed bug in test -f

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -14,10 +14,17 @@ SSL_CHAIN_CERT=/etc/nginx/ssl/${SSL_CHAIN_CERT}
 mkdir -p /etc/nginx/conf.d
 mkdir -p /etc/nginx/ssl
 
-#copy /etc/nginx/service*.conf if any of servcie*.conf mounted
-if [ -f /etc/nginx/service*.conf ]; then
-    cp -fv /etc/nginx/service*.conf /etc/nginx/conf.d/
+#collect services
+SERVICES=$(find "/etc/nginx/" -type f -maxdepth 1 -name "service*.conf")
+
+#exit, if service missing
+if [ ${#SERVICES} -eq 0 ]; then
+    echo "services missing"
+    exit 1
 fi
+
+#copy /etc/nginx/service*.conf if any of servcie*.conf mounted
+cp -fv /etc/nginx/service*.conf /etc/nginx/conf.d/
 
 #replace SSL_KEY, SSL_CERT and SSL_CHAIN_CERT by actual keys
 sed -i "s|SSL_KEY|${SSL_KEY}|g" /etc/nginx/conf.d/*.conf


### PR DESCRIPTION
Glob expression in the "test" causes an error when there are several services.

target string ` [ -f /etc/nginx/service.conf /etc/nginx/service2.conf /etc/nginx/service3.conf /etc/nginx/service4.conf ]`

```
Attaching to deploy_nginx_1
nginx_1  | + echo start nginx
nginx_1  | + cp /usr/share/zoneinfo/Asia/Yekaterinburg /etc/localtime
nginx_1  | start nginx
nginx_1  | + echo Asia/Yekaterinburg
nginx_1  | + echo ssl_key=le-key.pem, ssl_cert=le-crt.pem, ssl_chain_cert=le-chain-crt.pem
nginx_1  | + SSL_KEY=/etc/nginx/ssl/le-key.pem
nginx_1  | + SSL_CERT=/etc/nginx/ssl/le-crt.pem
nginx_1  | + SSL_CHAIN_CERT=/etc/nginx/ssl/le-chain-crt.pem
nginx_1  | + mkdir -p /etc/nginx/conf.d
nginx_1  | ssl_key=le-key.pem, ssl_cert=le-crt.pem, ssl_chain_cert=le-chain-crt.pem
nginx_1  | + mkdir -p /etc/nginx/ssl
nginx_1  | + [ -f /etc/nginx/service.conf /etc/nginx/service2.conf /etc/nginx/service3.conf /etc/nginx/service4.conf ]
nginx_1  | sh: /etc/nginx/service2.conf: unknown operand
nginx_1  | + sed -i s|SSL_KEY|/etc/nginx/ssl/le-key.pem|g /etc/nginx/conf.d/*.conf
nginx_1  | sed: /etc/nginx/conf.d/*.conf: No such file or directory
nginx_1  | + sed -i s|SSL_CERT|/etc/nginx/ssl/le-crt.pem|g /etc/nginx/conf.d/*.conf
nginx_1  | sed: /etc/nginx/conf.d/*.conf: No such file or directory
nginx_1  | + sed -i s|SSL_CHAIN_CERT|/etc/nginx/ssl/le-chain-crt.pem|g /etc/nginx/conf.d/*.conf
nginx_1  | sed: /etc/nginx/conf.d/*.conf: No such file or directory
nginx_1  | + [ ! -f /etc/nginx/ssl/dhparams.pem ]
nginx_1  | + mv -v /etc/nginx/conf.d /etc/nginx/conf.d.disabled
nginx_1  | '/etc/nginx/conf.d' -> '/etc/nginx/conf.d.disabled'
nginx_1  | + nginx -g daemon off;
```
