### PR TITLE
Add certificate domain name check

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -17,7 +17,7 @@ mkdir -p /etc/nginx/ssl
 #collect services
 SERVICES=$(find "/etc/nginx/" -type f -maxdepth 1 -name "service*.conf")
 
-#copy /etc/nginx/service*.conf if any of servcie*.conf mounted
+#copy /etc/nginx/service*.conf if any of service*.conf mounted
 if [ ${#SERVICES} -ne 0 ]; then
     cp -fv /etc/nginx/service*.conf /etc/nginx/conf.d/
 fi

--- a/script/le.sh
+++ b/script/le.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# scripts is trying to renew ceritifacte only if close (30 days) to expiration
+# scripts is trying to renew certificate only if close (30 days) to expiration
 # returns 0 only if certbot called.
 
 target_cert=/etc/nginx/ssl/le-crt.pem
@@ -20,7 +20,7 @@ fi
 echo "letsencrypt certificate will expire soon or missing, renewing..."
 certbot certonly -t -n --agree-tos --renew-by-default --email "${LE_EMAIL}" --webroot -w /usr/share/nginx/html -d ${LE_FQDN}
 le_result=$?
-if [ $le_result -ne 0 ]; then
+if [ ${le_result} -ne 0 ]; then
     echo "failed to run certbot"
     return 1
 fi

--- a/script/le.sh
+++ b/script/le.sh
@@ -23,7 +23,7 @@ if [ -f ${target_cert} ] && openssl x509 -checkend ${renew_before} -noout -in ${
         echo "letsencrypt certificate ${target_cert} still valid"
         return 1
     else
-        echo "letsencrypt certificate ${target_cert} is present, but contains wrong domains"
+        echo "letsencrypt certificate ${target_cert} is present, but doesn't contain expected domains"
         echo "expected: ${LE_FQDN}"
         echo "found:    ${CERT_FQDNS}"
     fi

--- a/script/le.sh
+++ b/script/le.sh
@@ -12,9 +12,21 @@ if [ "$LETSENCRYPT" != "true" ]; then
     return 1
 fi
 
-if [ -f ${target_cert} ] && openssl x509 -checkend  ${renew_before} -noout -in ${target_cert} ; then
-    echo "letsencrypt certificate still valid"
-    return 1
+# redirection to /dev/null to remove "Certificate will not expire" output
+if [ -f ${target_cert} ] && openssl x509 -checkend ${renew_before} -noout -in ${target_cert} > /dev/null ; then
+    # egrep to remove leading whitespaces
+    CERT_FQDNS=$(openssl x509 -in ${target_cert} -text -noout | egrep -o 'DNS.*')
+    # run and catch exit code separately because couldn't embed $@ into `if` line properly
+    set -- $(echo ${LE_FQDN} | tr ',' '\n'); for element in "$@"; do echo ${CERT_FQDNS} | grep -q $element ; done
+    CHECK_RESULT=$?
+    if [ ${CHECK_RESULT} -eq 0 ] ; then
+        echo "letsencrypt certificate ${target_cert} still valid"
+        return 1
+    else
+        echo "letsencrypt certificate ${target_cert} is present, but contains wrong domains"
+        echo "expected: ${LE_FQDN}"
+        echo "found:    ${CERT_FQDNS}"
+    fi
 fi
 
 echo "letsencrypt certificate will expire soon or missing, renewing..."


### PR DESCRIPTION
This PR add certificate domain name check, and renews it in case it's still new but doesn't contain any name from LE_FQDN variable (fix #23).
It's based on assumption what following output is present both for single domain and multi-domain certificate:
```bash
$ openssl x509 -in ssl/le-crt.pem -text -noout | grep DNS
                DNS:ksinia.net, DNS:terrty.net
```
I've tested it as hard as I could locally and it works fine on my two-domains setup.
Tested behavior:
- with too old cert it's renewed, logic is unaffected
- with one or all domain names present in certificate and cert up to date, output `letsencrypt certificate ssl/le-crt.pem still valid`, cert is not renewed
Important! If you have one domain_name and not too old cert for N domain names including it, it will not be regenerated for just one domain.
- with one or more domain names in LE_FQDN, which is not present in the certificate, it renews it with following output:
```bash
letsencrypt certificate ssl/le-crt.pem is present, but doesn't contain expected domains,
expected: nonexistent.org
found:    DNS:domain.net, DNS:domain.com
```
Notes to reviewer: I've didn't test this on one-domain setup, please apply openssl command above to single-domain le-crt.pem: if it have only domain name in output same as it have 2 in my example, then this logic will work good, this change can be merged. Otherwise please post me information about where domain name is written in single-domain cert, and I'll adjust the script.