### PR TITLE
Silence unneeded output in certificate create\update routine

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -46,10 +46,10 @@ mv -v /etc/nginx/conf.d /etc/nginx/conf.d.disabled
  echo "start letsencrypt updater"
  while :
  do
-	echo "trying to update letsencrypt ..."
+    echo "trying to update letsencrypt ..."
     /le.sh
-    rm -f /etc/nginx/conf.d/default.conf 2>/dev/null #remove default config, conflicting on 80
-    mv -v /etc/nginx/conf.d.disabled /etc/nginx/conf.d #enable
+    rm -f /etc/nginx/conf.d/default.conf 2>/dev/null #on the first run remove default config, conflicting on 80
+    mv -v /etc/nginx/conf.d.disabled /etc/nginx/conf.d 2>/dev/null #on the first run enable config back
     echo "reload nginx with ssl"
     nginx -s reload
     sleep 10d


### PR DESCRIPTION
This PR removes `mv: can't rename '/etc/nginx/conf.d.disabled': No such file or directory
reload nginx with ssl` error line from appearing, which is currently inevitable on every run excluding the first one, fixes #29.
Before this PR:
```
trying to update letsencrypt ...
letsencrypt certificate /etc/nginx/ssl/le-crt.pem still valid
mv: can't rename '/etc/nginx/conf.d.disabled': No such file or directory
reload nginx with ssl
2019/08/14 18:39:43 [notice] 173#173: signal process started
```
After this PR:
```
trying to update letsencrypt ...
letsencrypt certificate /etc/nginx/ssl/le-crt.pem still valid
'/etc/nginx/conf.d.disabled' -> '/etc/nginx/conf.d/conf.d.disabled'
reload nginx with ssl
2019/08/14 18:40:21 [notice] 196#196: signal process started
```