### PR TITLE
fix deprecated "ssl" directive

### DIFF
--- a/etc/service-example.conf
+++ b/etc/service-example.conf
@@ -1,10 +1,9 @@
 server {
-    listen   443;
+    listen   443 ssl;
     server_name _;
 
     root /srv/docroot/;
 
-    ssl    on;
     ssl_certificate         SSL_CERT;
     ssl_certificate_key     SSL_KEY;
     ssl_trusted_certificate SSL_CHAIN_CERT;


### PR DESCRIPTION
Warning on start: `nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /etc/nginx/conf.d/service.conf:7`