### PR TITLE
nginx.conf: add streams

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -68,3 +68,7 @@ http {
 
     include /etc/nginx/conf.d/*.conf;
 }
+
+stream {
+    include /etc/nginx/stream.d/*.conf;
+}


### PR DESCRIPTION
This patch adds the possibility to add stream config files in
/etc/nginx/stream.d/.

Starting with nginx 1.9 is is possible to proxy non-http streams to
backend service, more details in the offical docs[0].

This is usefull when you have a non-http service running but still want
to secure the connection via ssl.

[0]: https://nginx.org/en/docs/stream/ngx_stream_core_module.html

Signed-off-by: Paul Spooren <mail@aparcar.org>