### PR TITLE
Updated from stable-alpine to 1.17.8-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:stable-alpine
+FROM nginx:1.17.8-alpine
 
 ADD conf/nginx.conf /etc/nginx/nginx.conf
 #ADD conf/service.conf /etc/nginx/conf.d/service.conf


### PR DESCRIPTION
When trying to register cert for new domain you will get error

> Error: urn:acme:error:unauthorized :: The client lacks sufficient authorization :: Account creation on ACMEv1 is disabled. Please upgrade your ACME client to a version that supports ACMEv2 / RFC 8555. See https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430 for details.

nginx:stable-alpine is based on alpine 3.5.2 which contains certbot 0.9.3. This version of certbot doesn't support ACME v2.
