### PR TITLE
[Dockerfile] remove unused instruction, switch rm to no-cache, bump nginx to current stable version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM nginx:1.17.8-alpine
+FROM nginx:1.18-alpine
 
 ADD conf/nginx.conf /etc/nginx/nginx.conf
-#ADD conf/service.conf /etc/nginx/conf.d/service.conf
 
 ADD script/entrypoint.sh /entrypoint.sh
 ADD script/le.sh /le.sh
@@ -10,7 +9,6 @@ RUN \
  rm /etc/nginx/conf.d/default.conf && \
  chmod +x /entrypoint.sh && \
  chmod +x /le.sh && \
- apk add  --update certbot tzdata openssl && \
- rm -rf /var/cache/apk/*
+ apk add --no-cache --update certbot tzdata openssl
 
 CMD ["/entrypoint.sh"]


### PR DESCRIPTION
The latest version of Nginx is 1.19.3 but the latest stable version is 1.18 and I thought it would be better to switch to it.

`apk add --no-cache` and `apk add <...> && rm -rf /var/cache/apk/*` is the same thing, but first is a bit more clear in my opinion.