### PR TITLE
Clarify scripts and their description in the readme

### DIFF
--- a/script/le.sh
+++ b/script/le.sh
@@ -3,7 +3,6 @@
 # scripts is trying to renew certificate only if close (30 days) to expiration
 # returns 0 only if certbot called.
 
-target_cert=/etc/nginx/ssl/le-crt.pem
 # 30 days
 renew_before=2592000
 
@@ -13,17 +12,17 @@ if [ "$LETSENCRYPT" != "true" ]; then
 fi
 
 # redirection to /dev/null to remove "Certificate will not expire" output
-if [ -f ${target_cert} ] && openssl x509 -checkend ${renew_before} -noout -in ${target_cert} > /dev/null ; then
+if [ -f ${LE_SSL_CERT} ] && openssl x509 -checkend ${renew_before} -noout -in ${LE_SSL_CERT} > /dev/null ; then
     # egrep to remove leading whitespaces
-    CERT_FQDNS=$(openssl x509 -in ${target_cert} -text -noout | egrep -o 'DNS.*')
+    CERT_FQDNS=$(openssl x509 -in ${LE_SSL_CERT} -text -noout | egrep -o 'DNS.*')
     # run and catch exit code separately because couldn't embed $@ into `if` line properly
     set -- $(echo ${LE_FQDN} | tr ',' '\n'); for element in "$@"; do echo ${CERT_FQDNS} | grep -q $element ; done
     CHECK_RESULT=$?
     if [ ${CHECK_RESULT} -eq 0 ] ; then
-        echo "letsencrypt certificate ${target_cert} still valid"
+        echo "letsencrypt certificate ${LE_SSL_CERT} still valid"
         return 1
     else
-        echo "letsencrypt certificate ${target_cert} is present, but doesn't contain expected domains"
+        echo "letsencrypt certificate ${LE_SSL_CERT} is present, but doesn't contain expected domains"
         echo "expected: ${LE_FQDN}"
         echo "found:    ${CERT_FQDNS}"
     fi
@@ -38,7 +37,7 @@ if [ ${le_result} -ne 0 ]; then
 fi
 
 FIRST_FQDN=$(echo "$LE_FQDN" | cut -d"," -f1)
-cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/privkey.pem /etc/nginx/ssl/le-key.pem
-cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/fullchain.pem ${target_cert}
-cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/chain.pem /etc/nginx/ssl/le-chain-crt.pem
+cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/privkey.pem ${LE_SSL_KEY}
+cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/fullchain.pem ${LE_SSL_CERT}
+cp -fv /etc/letsencrypt/live/${FIRST_FQDN}/chain.pem ${LE_SSL_CHAIN_CERT}
 return 0


### PR DESCRIPTION
- Add a description of replacements to the Readme
- Add environment variables list to the Readme
- Make `TZ` environment variable explicitly optional
- Separate variables like `SSL_KEY` and `LE_SSL_KEY` to be explicit about the fact these are different
- Use new `LE_SSL_KEY` and other variables in `le.sh` instead of hardcoded filenames for certificates.

  The idea is that these variables are tied to Let's Encrypt certificates, and if you're using your own then you're not using these variables. Previous behavior (pick cert names by env variables, but we'll generate hardcoded names anyway) is less consistent.