### PR TITLE
Nginx updated to v19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.18-alpine
+FROM nginx:1.19-alpine
 
 ADD conf/nginx.conf /etc/nginx/nginx.conf
 


### PR DESCRIPTION
I need to turn on OSCP for client certificates (`ssl_ocsp`), but it's available only starting with Nginx 19.