### PR TITLE
Fix bugs with `CERT_FQDNS` check

### DIFF
--- a/script/le.sh
+++ b/script/le.sh
@@ -15,17 +15,22 @@ fi
 if [ -f ${LE_SSL_CERT} ] && openssl x509 -checkend ${renew_before} -noout -in ${LE_SSL_CERT} >/dev/null; then
     # egrep to remove leading whitespaces
     CERT_FQDNS=$(openssl x509 -in ${LE_SSL_CERT} -text -noout | egrep -o 'DNS.*')
-    # run and catch exit code separately because couldn't embed $@ into `if` line properly
     set -- $(echo ${LE_FQDN} | tr ',' '\n')
-    for element in "$@"; do echo ${CERT_FQDNS} | grep -q $element; done
-    CHECK_RESULT=$?
-    if [ ${CHECK_RESULT} -eq 0 ]; then
+    MISSING=false
+    for element in "$@"; do
+        if ! echo "${CERT_FQDNS}" | grep -Eq "DNS:${element}(,|$)"; then
+            MISSING=true
+            break
+        fi
+    done
+    if $MISSING; then
+        echo "letsencrypt certificate ${LE_SSL_CERT} is present, but doesn't contain expected domains"
+        echo "expected: ${LE_FQDN}"
+        echo "found:    ${CERT_FQDNS}"
+    else
         echo "letsencrypt certificate ${LE_SSL_CERT} still valid"
         return 1
     fi
-    echo "letsencrypt certificate ${LE_SSL_CERT} is present, but doesn't contain expected domains"
-    echo "expected: ${LE_FQDN}"
-    echo "found:    ${CERT_FQDNS}"
 fi
 
 echo "letsencrypt certificate will expire soon or missing, renewing..."


### PR DESCRIPTION
The previous implementation had 2 bugs:

1. The `echo ${CERT_FQDNS} | grep -q $element` check wasn't smart enough to detect issues
   where there's a cert for `foo.bar.com`, but we actually want a cert for
   `bar.com` (`bar.com` does show up in `foo.bar.com`). It also wasn't
   smart enough to handle the case where there's a cert for
   `foo.bar.com` and we want a cert for `foo.bar`, but that seems less
   likely to happen in practice. Regardless, neither should be a
   problem now. The check still isn't perfect, because we're using grep
   and there's the potential for some characters to be treated as
   special regex characters (such as `.`), but I don't know a nice way
   of fixing that in shell code (I'd be tempted to port things to a real
   programming language if we did want to fix it).
2. Looping over an array like we were doing doesn't have the desired
   behavior: we end up just charing about if the very last certificate
   is present or not. Proof:

   ```shell
    $ for foo in false true; do $foo; done; echo $?
    0
    $ for foo in true false; do $foo; done; echo $?
    1
    ```

    The right fix is to explicitly check the return value each time in
    the for loop, which is what I've done here.