### PR TITLE
Add IPv6 listen directive

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -55,6 +55,8 @@ http {
 
     server {
         listen 80;
+        listen [::]:80;
+
         server_name _;
 
         root   /usr/share/nginx/html;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,7 +1,7 @@
 user  nginx;
 worker_processes  1;
 
-error_log  /var/log/nginx/error.log warn;
+error_log  stderr warn;
 pid        /var/run/nginx.pid;
 
 
@@ -18,7 +18,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log  /dev/stdout  main;
 
     sendfile        on;
 


### PR DESCRIPTION
Nginx has IPv4-only listening socket by default.
`listen [::]:80` needs to be added to accept IPv6 connections.