### PR TITLE
Fix issue #51: container not stopped with SIGTERM

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -78,4 +78,4 @@ mv -v /etc/nginx/stream.d /etc/nginx/stream.d.disabled
  done
 ) &
 
-nginx -g "daemon off;"
+exec nginx -g "daemon off;"


### PR DESCRIPTION
Commands `docker stop` or `docker restart` attempt a graceful shutdown by sending SIGTERM to the main process of the container which is `entrypoint.sh`, however the shell does not propagate the signal to the nginx process. This causes the container not to exit and instead to be killed with SIGKILL after 10 seconds.

The proposed solution is explained here: https://stackoverflow.com/a/57575961.