### PR TITLE
Remove update of Docker images for Nginx to uneven numbers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    # ignore updates with odd numbers like 1.27 and 1.29 but allow 1.28 and 1.30
+    ignore:
+      - dependency-name: "nginx"
+        versions: ["1.27", "1.29", "1.31", "1.33", "1.35", "1.37", "1.39"]


### PR DESCRIPTION
We're interested in the newest (even versions), but Dependabot is also proposing uneven versions. This change fixes that.