### PR TITLE
Return DockerHub login to build workflow, update ghcr.io org name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,8 @@ jobs:
         run: |
           ref="$(echo ${GITHUB_REF} | cut -d'/' -f3)"
           echo GITHUB_REF - $ref
+          echo ${DOCKER_HUB_TOKEN} | docker login -u umputun --password-stdin
           docker buildx build \
               --build-arg CI=github --build-arg GITHUB_SHA=${GITHUB_SHA} --build-arg GIT_BRANCH=${ref} \
               --platform linux/amd64,linux/arm/v7,linux/arm64 \
-              -t ghcr.io/umputun/nginx-le:${ref} -t umputun/nginx-le:${ref} .
+              -t ghcr.io/nginx-le/nginx-le:${ref} -t umputun/nginx-le:${ref} .


### PR DESCRIPTION
In case the `ghcr.io/nginx-le/nginx-le` package won't be released, Please follow the documentation below:
https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-in-a-github-actions-workflow

DockerHub package is not released for sure since 6e8696252e894877060daa05a7abc6c2ea5b7841 and would be released only after this change.

This resolves #76.